### PR TITLE
Synchronize only when needed

### DIFF
--- a/bin/hashbangctl
+++ b/bin/hashbangctl
@@ -54,7 +54,7 @@ def print_actions():
     print("\nActions:\n")
     for key,desc in menu_items:
         print("  %s - %s" % (key,desc))
-    
+
 def main_menu():
     print("\nLDAP User Details:\n")
     print("  Login : %s" % user['login'])
@@ -80,12 +80,12 @@ def ldap_sync():
         pubkeys = user['pubkeys'],
         shell = user['shell'],
         name = user['name'],
-    ) 
+    )
 
 main_menu()
 
 while True:
- 
+
     key = getch()
 
     if key in [ key for k,v in menu_items ]:
@@ -136,7 +136,7 @@ while True:
             print('\nPublic Keys updated.')
 
         print('\nPlease press [Enter] to continue')
-                
+
     elif key == 'd':
         if (len(user['pubkeys']) == 0):
             print('\nThere are no SSH Public Keys to delete')

--- a/bin/hashbangctl
+++ b/bin/hashbangctl
@@ -46,9 +46,12 @@ menu_items = [
     ('s',"Change Shell"),
     ('a',"Add SSH Public Key"),
     ('d',"Delete SSH Public Key"),
+    ('S',"Save changes"),
     ('h',"Help"),
     ('q',"Quit\n"),
 ]
+
+synced = True
 
 def print_actions():
     print("\nActions:\n")
@@ -82,6 +85,8 @@ def ldap_sync():
         name = user['name'],
     )
 
+    synced = True
+
 main_menu()
 
 while True:
@@ -102,7 +107,7 @@ while True:
 
     elif key == 'n':
         user['name'] = raw_input("Enter new name: ")
-        ldap_sync();
+        synced = False
         print('\nName Updated.')
         print('\nPlease press [Enter] to continue')
 
@@ -113,7 +118,7 @@ while True:
             print('Error: \n"%s" is not an available shell' % shell)
         else:
             user['shell'] = shell
-            ldap_sync()
+            synced = False
             print('\nShell Updated.')
 
         print('\nPlease press [Enter] to continue')
@@ -132,7 +137,7 @@ while True:
 
         elif valid_pubkey:
             user['pubkeys'].append(pubkey)
-            ldap_sync()
+            synced = False
             print('\nPublic Keys updated.')
 
         print('\nPlease press [Enter] to continue')
@@ -150,12 +155,29 @@ while True:
             elif ord(delkey) >= ord('0') and ord(delkey) <= ord(str(len(user['pubkeys']))):
                 print(delkey)
                 del user['pubkeys'][int(delkey)]
-                ldap_sync()
+                synced = False
                 print('\nKey Deleted: %s' % delkey)
             else:
                 print('\nInvalid key number specified')
 
             print('\nPlease press [Enter] to continue')
 
+    elif key == 'S':
+        if not synced:
+            ldap_sync()
+            print('Changes saved.\n')
+        else:
+            print('No changes need saving.\n')
+
     elif key == 'q':
+        if not synced:
+            print('\nSome changes have not been saved.  Save now? [Y/n]')
+            while True:
+                key = getch()
+                if key in [ '\n', 'Y', 'y' ]:
+                    ldap_sync()
+                    break
+                elif key in [ 'n', 'N' ] or ord(key) == 3:
+                    break
+            print('\n')
         break;


### PR DESCRIPTION
This is a proposal to make `hashbangctl` only synchronize with LDAP on demand, rather than eagerly.

This would make some things more rational when moving to a design where the front-end is not privileged, and split from a daemon backend;  it would of course still be possible to synchronize eagerly, but I'm unsure we need/want that.
